### PR TITLE
typeを指定できるようにする

### DIFF
--- a/sclazy.js
+++ b/sclazy.js
@@ -34,15 +34,37 @@
       }, false);
     },
 
+    getData: function(type) {
+      type = type || this.type;
+      return this._data[type] = this._data[type] || {
+        type: type,
+        items: [],
+        page: 1,
+        addItems: this.addItems,
+        addItem: this.addItems,
+      };
+    },
+
+    set items(items) {
+      this.getData().items = items;
+    },
+
     get items() {
-      return this._items[this.type] = this._items[this.type] || [];
+      return this.getData().items;
+    },
+
+    set page(v) {
+      this.getData().page = v;
+    },
+
+    get page() {
+      return this.getData().page;
     },
 
     reset: function() {
       this._locked = false;
       this._more = true;
-      this._items = {};
-      this.page = 1;
+      this._data = {};
 
       return this;
     },
@@ -53,7 +75,7 @@
 
       this.lock();
 
-      this.trigger('load');
+      this.trigger('load', this.getData());
     },
 
     next: function(more) {
@@ -87,9 +109,7 @@
     },
 
     addItem: function(item) {
-      this.items.push(item);
-      this.update();
-      return this;
+      return this.addItems([item]);
     },
 
     addItems: function(items) {

--- a/sclazy.js
+++ b/sclazy.js
@@ -14,6 +14,7 @@
       this.onload       = options.onload;
       this.onscrollend  = options.onscrollend;
       this.onpulldown   = options.onpulldown;
+      this.type         = options.type || 'default';
 
       var self = this;
       this.target.addEventListener('scroll', function(e) {
@@ -33,11 +34,14 @@
       }, false);
     },
 
+    get items() {
+      return this._items[this.type] = this._items[this.type] || [];
+    },
+
     reset: function() {
       this._locked = false;
       this._more = true;
-
-      this.items = [];
+      this._items = {};
       this.page = 1;
 
       return this;

--- a/test/data/1.json
+++ b/test/data/1.json
@@ -1,0 +1,43 @@
+{
+  "data": {
+    "next_page": true,
+    "items": [
+      {"title": "TEST TITLE A"},
+      {"title": "TEST TITLE B"},
+      {"title": "TEST TITLE C"},
+      {"title": "TEST TITLE D"},
+      {"title": "TEST TITLE E"},
+      {"title": "TEST TITLE F"},
+      {"title": "TEST TITLE G"},
+      {"title": "TEST TITLE H"},
+      {"title": "TEST TITLE I"},
+      {"title": "TEST TITLE J"},
+      {"title": "TEST TITLE K"},
+      {"title": "TEST TITLE L"},
+      {"title": "TEST TITLE M"},
+      {"title": "TEST TITLE N"},
+      {"title": "TEST TITLE O"},
+      {"title": "TEST TITLE P"},
+      {"title": "TEST TITLE Q"},
+      {"title": "TEST TITLE R"},
+      {"title": "TEST TITLE S"},
+      {"title": "TEST TITLE T"},
+      {"title": "TEST TITLE U"},
+      {"title": "TEST TITLE V"},
+      {"title": "TEST TITLE W"},
+      {"title": "TEST TITLE X"},
+      {"title": "TEST TITLE Y"},
+      {"title": "TEST TITLE Z"},
+      {"title": "TEST TITLE 1"},
+      {"title": "TEST TITLE 2"},
+      {"title": "TEST TITLE 3"},
+      {"title": "TEST TITLE 4"},
+      {"title": "TEST TITLE 5"},
+      {"title": "TEST TITLE 6"},
+      {"title": "TEST TITLE 7"},
+      {"title": "TEST TITLE 8"},
+      {"title": "TEST TITLE 9"},
+      {"title": "TEST TITLE 0"}
+    ]
+  }
+}

--- a/test/data/2.json
+++ b/test/data/2.json
@@ -1,0 +1,42 @@
+{
+  "data": {
+    "items": [
+      {"title": "test title a"},
+      {"title": "test title b"},
+      {"title": "test title c"},
+      {"title": "test title d"},
+      {"title": "test title e"},
+      {"title": "test title f"},
+      {"title": "test title g"},
+      {"title": "test title h"},
+      {"title": "test title i"},
+      {"title": "test title j"},
+      {"title": "test title k"},
+      {"title": "test title l"},
+      {"title": "test title m"},
+      {"title": "test title n"},
+      {"title": "test title o"},
+      {"title": "test title p"},
+      {"title": "test title q"},
+      {"title": "test title r"},
+      {"title": "test title s"},
+      {"title": "test title t"},
+      {"title": "test title u"},
+      {"title": "test title v"},
+      {"title": "test title w"},
+      {"title": "test title x"},
+      {"title": "test title y"},
+      {"title": "test title z"},
+      {"title": "test title 1"},
+      {"title": "test title 2"},
+      {"title": "test title 3"},
+      {"title": "test title 4"},
+      {"title": "test title 5"},
+      {"title": "test title 6"},
+      {"title": "test title 7"},
+      {"title": "test title 8"},
+      {"title": "test title 9"},
+      {"title": "test title 0"}
+    ]
+  }
+}

--- a/test/scroll-tab.html
+++ b/test/scroll-tab.html
@@ -29,6 +29,9 @@
 app.absolute.s-full.bg-lightgray
   div.container.bg-white.s-full
     div.s-full.overflow-scroll(ref='content')
+      div.f.flex-between.w-full
+        button.button.w-full(onclick='{switchTest1}') TEST1
+        button.button.w-full(onclick='{switchTest2}') TEST2
       div.item.border.m8.p16(each='{item, index in sclazy.items}')
         div {index}. {item.title}
       div.p16.f.fh(if='{sclazy.isMore()}') loading
@@ -56,11 +59,13 @@ app.absolute.s-full.bg-lightgray
     this.on('mount', function() {
       this.sclazy = Sclazy({
         target: this.refs.content,
-        onload: () => {
-          ref.child(this.sclazy.page++ + '.json').get().then((res) => {
-            this.sclazy.addItems(res.data.items);
-            this.sclazy.next(res.data.next_page != null);
-            this.update();
+        onload: (e) => {
+          ref.child(e.page++ + '.json').get().then((res) => {
+            setTimeout(() => {
+              e.addItems(res.data.items);
+              this.sclazy.next(res.data.next_page != null);
+              this.update();
+            }, Math.random() * 500);
           });
         },
         onscrollend: () => {
@@ -75,6 +80,16 @@ app.absolute.s-full.bg-lightgray
       this.sclazy.load();
       this.update();
     });
+    
+    this.switchTest1 = () => {
+      this.sclazy.type = 'test1';
+      this.sclazy.reset().load();
+    };
+
+    this.switchTest2 = () => {
+      this.sclazy.type = 'test2';
+      this.sclazy.reset().load();
+    };
 
 </script>
 

--- a/test/scroll.html
+++ b/test/scroll.html
@@ -29,6 +29,9 @@
 app.absolute.s-full.bg-lightgray
   div.container.bg-white.s-full
     div.s-full.overflow-scroll(ref='content')
+      div.f.flex-between.w-full
+        button.button.w-full(onclick='{switchTest1}') TEST1
+        button.button.w-full(onclick='{switchTest2}') TEST2
       div.item.border.m8.p16(each='{item, index in sclazy.items}')
         div {index}. {item.title}
       div.p16.f.fh(if='{sclazy.isMore()}') loading
@@ -49,7 +52,7 @@ app.absolute.s-full.bg-lightgray
   
   script.
     var ref = Firerest.create({
-      api: 'https://noteput-api.herokuapp.com/v1',
+      api: 'data',
       debug: true,
     });
     
@@ -57,12 +60,9 @@ app.absolute.s-full.bg-lightgray
       this.sclazy = Sclazy({
         target: this.refs.content,
         onload: () => {
-          ref.child('items').get({
-            page: this.sclazy.page++,
-            per: 32,
-          }).then((res) => {
+          ref.child(this.sclazy.page++ + '.json').get().then((res) => {
             this.sclazy.addItems(res.data.items);
-            this.sclazy.next(res.data.page_info.next_page != null);
+            this.sclazy.next(res.data.next_page != null);
             this.update();
           });
         },
@@ -78,6 +78,16 @@ app.absolute.s-full.bg-lightgray
       this.sclazy.load();
       this.update();
     });
+    
+    this.switchTest1 = () => {
+      this.sclazy.type = 'test1';
+      this.sclazy.reset().load();
+    };
+
+    this.switchTest2 = () => {
+      this.sclazy.type = 'test2';
+      this.sclazy.reset().load();
+    };
 
 </script>
 


### PR DESCRIPTION
typeを変更するとtypeごとにitems, pageが切り替わります
何も考えてない場合は今まで通りのコードで動きます
onload の第一引数を使ってpageのインクリメントやitemsの追加を行います
イベントオブジェクトからデータを操作するのは、非同期処理によって、対象のオブジェクトが変更されないようにするためです。

```
      onload: (e) => {
          ref.child('items').get({
            page: e.page++,
          }).then((res) => {
              e.addItems(res.data.items);
              this.sclazy.next(res.data.next_page != null);
              this.update();
          });
        },

```

